### PR TITLE
#56 Enable custom Handbrake encoding parameters

### DIFF
--- a/video_transcode.sh
+++ b/video_transcode.sh
@@ -15,6 +15,12 @@ TIMESTAMP=$5
 	TRANSSTART=$(date +%s);
 	echo "Start video transcoding script" >> "$LOG"
 
+	if [ -z "$HB_PRESET" ]; then
+		HB_PRESET_PARAMETER=""
+	else
+		HB_PRESET_PARAMETER="--preset ${HB_PRESET}"
+	fi
+
 	if [ "$HAS_NICE_TITLE" = true ]; then
 		echo "transcoding with a nice title" >> "$LOG"
 		DEST="${ARMPATH}/${LABEL}"
@@ -37,7 +43,7 @@ TIMESTAMP=$5
 	elif [ "$RIPMETHOD" = "backup" ] && [ "$MAINFEATURE" = true ] && [ "$ID_CDROM_MEDIA_BD" = "1" ]; then
 		echo "Transcoding BluRay main feature only." >> "$LOG"
 		# shellcheck disable=SC2086
-		$HANDBRAKE_CLI -i "$SRC" -o "$DEST/$LABEL.$DEST_EXT" --main-feature --preset="$HB_PRESET" $HB_ARGS 2>> "$LOG"
+		$HANDBRAKE_CLI -i "$SRC" -o "$DEST/$LABEL.$DEST_EXT" --main-feature $HB_PRESET_PARAMETER $HB_ARGS 2>> "$LOG"
 		rmdir "$SRC"	
 	elif [ "$RIPMETHOD" = "backup" ] && [ "$MAINFEATURE" = false ] && [ "$ID_CDROM_MEDIA_BD" = "1" ]; then		
 		echo "Transcoding BluRay all titles above minlength." >> "$LOG"
@@ -60,7 +66,7 @@ TIMESTAMP=$5
 			if [ $SEC -gt "$MINLENGTH" ]; then
 				echo "HandBraking title $TITLE"
 				# shellcheck disable=SC2086
-				$HANDBRAKE_CLI -i "$SRC" -o "$DEST/$LABEL-$TITLE.$DEST_EXT" --min-duration="$MINLENGTH" -t "$TITLE" --preset="$HB_PRESET" $HB_ARGS 2  >> "$LOG"
+				$HANDBRAKE_CLI -i "$SRC" -o "$DEST/$LABEL-$TITLE.$DEST_EXT" --min-duration="$MINLENGTH" -t "$TITLE" $HB_PRESET_PARAMETER $HB_ARGS 2  >> "$LOG"
 
 				# Check for main title and rename
 				if [ "$MAINTITLENO" = "$TITLE" ] && [ "$HAS_NICE_TITLE" = true ]; then
@@ -76,7 +82,7 @@ TIMESTAMP=$5
 		echo "Transcoding DVD main feature only." >> "$LOG"
 		# echo "$HANDBRAKE_CLI -i $DEVNAME -o \"${DEST}/${LABEL}.${DEST_EXT}\" --main-feature --preset="${HB_PRESET}" --subtitle scan -F 2" >> $LOG
 		# shellcheck disable=SC2086
-        $HANDBRAKE_CLI -i "$DEVNAME" -o "${DEST}/${LABEL}.${DEST_EXT}" --main-feature --preset="${HB_PRESET}" $HB_ARGS 2>> "$LOG"
+        $HANDBRAKE_CLI -i "$DEVNAME" -o "${DEST}/${LABEL}.${DEST_EXT}" --main-feature $HB_PRESET_PARAMETER $HB_ARGS 2>> "$LOG"
 		eject "$DEVNAME"
 	else
 		echo "Transcoding all files." >> "$LOG"
@@ -90,7 +96,7 @@ TIMESTAMP=$5
 
 			echo "Transcoding file $FILE" >> "$LOG"
 				# shellcheck disable=SC2086
-                $HANDBRAKE_CLI -i "$SRC/$FILE" -o "$DEST/$filename.$DEST_EXT" --preset="$HB_PRESET" $HB_ARGS 2>> "$LOG"
+                $HANDBRAKE_CLI -i "$SRC/$FILE" -o "$DEST/$filename.$DEST_EXT" $HB_PRESET_PARAMETER $HB_ARGS 2>> "$LOG"
 			rm "$SRC/$FILE"
        		done
 		rmdir "$SRC"


### PR DESCRIPTION
If $HB_PRESET is left empty in config, do not pass --preset to Handbrake. Encoding parameters can then be set in $HB_ARGS.